### PR TITLE
Update to Fox v0.24.0 and Refactor Timeout Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,18 +31,18 @@ package main
 
 import (
 	"errors"
-	"github.com/tigerwill90/fox"
-	"github.com/tigerwill90/foxtimeout"
 	"log"
 	"net/http"
 	"time"
+
+	"github.com/tigerwill90/fox"
+	"github.com/tigerwill90/foxtimeout"
 )
 
 func main() {
 	f, err := fox.New(
 		fox.DefaultOptions(),
-		fox.WithMiddlewareFor(
-			fox.RouteHandler,
+		fox.WithMiddleware(
 			foxtimeout.Middleware(2*time.Second),
 		),
 	)
@@ -53,6 +53,8 @@ func main() {
 	f.MustHandle(http.MethodGet, "/hello/{name}", func(c fox.Context) {
 		_ = c.String(http.StatusOK, "hello %s\n", c.Param("name"))
 	})
+	f.MustHandle(http.MethodGet, "/download/{filepath}", DownloadHandler, foxtimeout.None())
+	f.MustHandle(http.MethodGet, "/workflow/{id}/start", WorkflowHandler, foxtimeout.After(15*time.Second))
 
 	if err = http.ListenAndServe(":8080", f); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		log.Fatalln(err)

--- a/annotation.go
+++ b/annotation.go
@@ -1,0 +1,31 @@
+package foxtimeout
+
+import (
+	"time"
+
+	"github.com/tigerwill90/fox"
+)
+
+type key struct{}
+
+var ctxKey key
+
+// After returns a RouteOption that sets a custom timeout duration for a specific route.
+// This allows individual routes to have different timeout values than the global timeout.
+func After(dt time.Duration) fox.RouteOption {
+	return fox.WithAnnotation(ctxKey, dt)
+}
+
+// None returns a RouteOption that disables the timeout for a specific route.
+// This is useful for long-running operations like file uploads or SSE endpoints.
+func None() fox.RouteOption {
+	return fox.WithAnnotation(ctxKey, time.Duration(0))
+}
+
+func unwrapRouteTimeout(r *fox.Route) (time.Duration, bool) {
+	dt := r.Annotation(ctxKey)
+	if dt != nil {
+		return dt.(time.Duration), true
+	}
+	return 0, false
+}

--- a/annotation.go
+++ b/annotation.go
@@ -23,9 +23,11 @@ func None() fox.RouteOption {
 }
 
 func unwrapRouteTimeout(r *fox.Route) (time.Duration, bool) {
-	dt := r.Annotation(ctxKey)
-	if dt != nil {
-		return dt.(time.Duration), true
+	if r != nil {
+		dt := r.Annotation(ctxKey)
+		if dt != nil {
+			return dt.(time.Duration), true
+		}
 	}
 	return 0, false
 }

--- a/go.mod
+++ b/go.mod
@@ -6,13 +6,15 @@ toolchain go1.24.2
 
 require (
 	github.com/stretchr/testify v1.10.0
-	github.com/tigerwill90/fox v0.23.0
+	github.com/tigerwill90/fox v0.24.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/sys v0.32.0 // indirect
+	golang.org/x/net v0.43.0 // indirect
+	golang.org/x/sys v0.35.0 // indirect
+	golang.org/x/text v0.28.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,16 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tigerwill90/fox v0.23.0 h1:EOKhB58GWNNNWB8k+DalO95mAMHdo1kM1Kgn9o+3stY=
 github.com/tigerwill90/fox v0.23.0/go.mod h1:0XnvOqFSoEQAe7K7Sqjt4iFK0OoQdVK3jAEclUEmRqo=
+github.com/tigerwill90/fox v0.24.0 h1:SHArsbDIttHS1wJT7GjEhRF5pJO38E76J9v8gz07FJA=
+github.com/tigerwill90/fox v0.24.0/go.mod h1:CRfZwmdl435A8v4m5XUUxqFk2qVBlVeKjtUX8Vw2DNk=
+golang.org/x/net v0.43.0 h1:lat02VYK2j4aLzMzecihNvTlJNQUq316m2Mr9rnM6YE=
+golang.org/x/net v0.43.0/go.mod h1:vhO1fvI4dGsIjh73sWfUVjj3N7CA9WkKJNQm2svM6Jg=
 golang.org/x/sys v0.32.0 h1:s77OFDvIQeibCmezSnk/q6iAfkdiQaJi4VzroCFrN20=
 golang.org/x/sys v0.32.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=
+golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/text v0.28.0 h1:rhazDwis8INMIwQ4tpjLDzUhx6RlXqZNPEM0huQojng=
+golang.org/x/text v0.28.0/go.mod h1:U8nCwOR8jO/marOQ0QbDiOngZVEBB7MAiitBuMjXiNU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/options.go
+++ b/options.go
@@ -5,9 +5,10 @@
 package foxtimeout
 
 import (
-	"github.com/tigerwill90/fox"
 	"net/http"
 	"time"
+
+	"github.com/tigerwill90/fox"
 )
 
 type config struct {

--- a/options.go
+++ b/options.go
@@ -12,9 +12,10 @@ import (
 )
 
 type config struct {
-	resolver Resolver
-	resp     fox.HandlerFunc
-	filters  []Filter
+	resolver               Resolver
+	resp                   fox.HandlerFunc
+	filters                []Filter
+	enableAbortRequestBody bool
 }
 
 type Option interface {
@@ -83,5 +84,14 @@ func DefaultTimeoutResponse(c fox.Context) {
 func WithTimeoutResolver(resolver Resolver) Option {
 	return optionFunc(func(c *config) {
 		c.resolver = resolver
+	})
+}
+
+// WithAbortRequestBody controls whether to set a read deadline on the request
+// when a timeout occurs. When enabled, subsequent reads from the request body
+// will immediately fail after a timeout.
+func WithAbortRequestBody(enable bool) Option {
+	return optionFunc(func(c *config) {
+		c.enableAbortRequestBody = enable
 	})
 }

--- a/options.go
+++ b/options.go
@@ -6,13 +6,11 @@ package foxtimeout
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/tigerwill90/fox"
 )
 
 type config struct {
-	resolver               Resolver
 	resp                   fox.HandlerFunc
 	filters                []Filter
 	enableAbortRequestBody bool
@@ -23,22 +21,6 @@ type Option interface {
 }
 
 type Filter func(c fox.Context) (skip bool)
-
-// Resolver defines the interface for resolving a timeout duration dynamically based on [fox.Context].
-// A [time.Duration] is returned if a custom timeout is applicable, along with a boolean indicating if the
-// duration was resolved.
-type Resolver interface {
-	Resolve(c fox.Context) (dt time.Duration, ok bool)
-}
-
-// The TimeoutResolverFunc type is an adapter to allow the use of ordinary functions as [Resolver]. If f is a
-// function with the appropriate signature, TimeoutResolverFunc(f) is a TimeoutResolverFunc that calls f.
-type TimeoutResolverFunc func(c fox.Context) (dt time.Duration, ok bool)
-
-// Resolve calls f(c).
-func (f TimeoutResolverFunc) Resolve(c fox.Context) (dt time.Duration, ok bool) {
-	return f(c)
-}
 
 type optionFunc func(*config)
 
@@ -76,15 +58,6 @@ func WithResponse(h fox.HandlerFunc) Option {
 // DefaultTimeoutResponse sends a default 503 Service Unavailable response.
 func DefaultTimeoutResponse(c fox.Context) {
 	http.Error(c.Writer(), http.StatusText(http.StatusServiceUnavailable), http.StatusServiceUnavailable)
-}
-
-// WithTimeoutResolver sets a custom [Resolver] to determine the timeout dynamically based on [fox.Context].
-// If the resolver returns false, the default timeout is applied. Keep in mind that a resolver is invoked for each request,
-// so they should be simple and efficient.
-func WithTimeoutResolver(resolver Resolver) Option {
-	return optionFunc(func(c *config) {
-		c.resolver = resolver
-	})
 }
 
 // WithAbortRequestBody controls whether to set a read deadline on the request

--- a/timeout.go
+++ b/timeout.go
@@ -9,7 +9,6 @@ package foxtimeout
 
 import (
 	"bytes"
-	"cmp"
 	"context"
 	"fmt"
 	"net/http"
@@ -38,21 +37,14 @@ type Timeout struct {
 // Middleware returns a [fox.MiddlewareFunc] with a specified timeout and options.
 // This middleware function, when used, will ensure HTTP handlers don't exceed the given timeout duration.
 func Middleware(dt time.Duration, opts ...Option) fox.MiddlewareFunc {
-	return New(dt, opts...).Timeout
+	return create(dt, opts...).Timeout
 }
 
-// New creates and initializes a new [Timeout] middleware with the given timeout duration
-// and optional settings.3
-func New(dt time.Duration, opts ...Option) *Timeout {
+func create(dt time.Duration, opts ...Option) *Timeout {
 	cfg := defaultConfig()
 	for _, opt := range opts {
 		opt.apply(cfg)
 	}
-
-	cfg.resolver = cmp.Or[Resolver](
-		cfg.resolver,
-		TimeoutResolverFunc(func(c fox.Context) (time.Duration, bool) { return dt, true }),
-	)
 
 	return &Timeout{
 		dt:  dt,
@@ -68,16 +60,7 @@ func New(dt time.Duration, opts ...Option) *Timeout {
 //
 // Timeout supports the [http.Pusher] interface but does not support the [http.Hijacker] or [http.Flusher] interfaces.
 func (t *Timeout) Timeout(next fox.HandlerFunc) fox.HandlerFunc {
-	if t.dt <= 0 {
-		return func(c fox.Context) {
-			next(c)
-		}
-	}
-
 	return func(c fox.Context) {
-
-		ctx, cancel := t.resolveContext(c)
-		defer cancel()
 
 		for _, f := range t.cfg.filters {
 			if f(c) {
@@ -85,6 +68,15 @@ func (t *Timeout) Timeout(next fox.HandlerFunc) fox.HandlerFunc {
 				return
 			}
 		}
+
+		dt := t.resolveTimeout(c)
+		if dt <= 0 {
+			next(c)
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(c.Request().Context(), dt)
+		defer cancel()
 
 		req := c.Request().WithContext(ctx)
 		done := make(chan struct{})
@@ -145,12 +137,11 @@ func (t *Timeout) Timeout(next fox.HandlerFunc) fox.HandlerFunc {
 	}
 }
 
-func (t *Timeout) resolveContext(c fox.Context) (ctx context.Context, cancel context.CancelFunc) {
-	dt, ok := t.cfg.resolver.Resolve(c)
-	if ok {
-		return context.WithTimeout(c.Request().Context(), dt)
+func (t *Timeout) resolveTimeout(c fox.Context) time.Duration {
+	if dt, ok := unwrapRouteTimeout(c.Route()); ok {
+		return dt
 	}
-	return context.WithTimeout(c.Request().Context(), t.dt)
+	return t.dt
 }
 
 func checkWriteHeaderCode(code int) {

--- a/timeout.go
+++ b/timeout.go
@@ -137,7 +137,9 @@ func (t *Timeout) Timeout(next fox.HandlerFunc) fox.HandlerFunc {
 			default:
 				tw.err = err
 			}
-			_ = w.SetReadDeadline(time.Now())
+			if t.cfg.enableAbortRequestBody {
+				_ = w.SetReadDeadline(time.Now())
+			}
 			t.cfg.resp(c)
 		}
 	}

--- a/timeout.go
+++ b/timeout.go
@@ -12,12 +12,13 @@ import (
 	"cmp"
 	"context"
 	"fmt"
-	"github.com/tigerwill90/fox"
 	"net/http"
 	"runtime"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/tigerwill90/fox"
 )
 
 var (

--- a/timeout_test.go
+++ b/timeout_test.go
@@ -6,15 +6,16 @@ package foxtimeout
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/tigerwill90/fox"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tigerwill90/fox"
 )
 
 func success201response(c fox.Context) {

--- a/timeout_test.go
+++ b/timeout_test.go
@@ -121,14 +121,10 @@ func TestMiddleware_ErrNotSupported(t *testing.T) {
 	f.ServeHTTP(w, req)
 }
 
-func TestMiddleware_WithTimeoutResolver(t *testing.T) {
-	resolver := WithTimeoutResolver(TimeoutResolverFunc(func(c fox.Context) (dt time.Duration, ok bool) {
-		return 2 * time.Second, true
-	}))
-
-	f, err := fox.New(fox.WithMiddleware(Middleware(1*time.Millisecond, resolver)))
+func TestMiddleware_WithAfter(t *testing.T) {
+	f, err := fox.New(fox.WithMiddleware(Middleware(1 * time.Millisecond)))
 	require.NoError(t, err)
-	f.MustHandle(http.MethodGet, "/foo", success201response)
+	f.MustHandle(http.MethodGet, "/foo", success201response, After(2*time.Second))
 
 	req := httptest.NewRequest(http.MethodGet, "/foo", nil)
 	w := httptest.NewRecorder()
@@ -138,24 +134,22 @@ func TestMiddleware_WithTimeoutResolver(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("%s\n", http.StatusText(http.StatusCreated)), w.Body.String())
 }
 
-func ExampleWithTimeoutResolver() {
-	type key struct{}
-	annotKey := key{}
+func TestMiddleware_WithNone(t *testing.T) {
+	f, err := fox.New(fox.WithMiddleware(Middleware(1 * time.Millisecond)))
+	require.NoError(t, err)
+	f.MustHandle(http.MethodGet, "/foo", success201response, None())
 
-	resolver := TimeoutResolverFunc(func(c fox.Context) (dt time.Duration, ok bool) {
-		v := c.Route().Annotation(annotKey)
-		if v != nil {
-			dt, ok = v.(time.Duration)
-			return
-		}
-		return 0, false
-	})
+	req := httptest.NewRequest(http.MethodGet, "/foo", nil)
+	w := httptest.NewRecorder()
+	f.ServeHTTP(w, req)
 
+	assert.Equal(t, http.StatusCreated, w.Code)
+	assert.Equal(t, fmt.Sprintf("%s\n", http.StatusText(http.StatusCreated)), w.Body.String())
+}
+
+func ExampleAfter() {
 	f, err := fox.New(
-		fox.WithMiddleware(Middleware(
-			2*time.Second,
-			WithTimeoutResolver(resolver),
-		)),
+		fox.WithMiddleware(Middleware(2 * time.Second)),
 	)
 	if err != nil {
 		panic(err)
@@ -167,5 +161,22 @@ func ExampleWithTimeoutResolver() {
 	f.MustHandle(http.MethodGet, "/long", func(c fox.Context) {
 		time.Sleep(10 * time.Second)
 		c.Writer().WriteHeader(http.StatusOK)
-	}, fox.WithAnnotation(annotKey, 12*time.Second))
+	}, After(12*time.Second))
+}
+
+func ExampleNone() {
+	f, err := fox.New(
+		fox.WithMiddleware(Middleware(2 * time.Second)),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	f.MustHandle(http.MethodGet, "/hello/{name}", func(c fox.Context) {
+		_ = c.String(http.StatusOK, "hello %s\n", c.Param("name"))
+	})
+	f.MustHandle(http.MethodGet, "/long", func(c fox.Context) {
+		time.Sleep(10 * time.Second)
+		c.Writer().WriteHeader(http.StatusOK)
+	}, None())
 }

--- a/writer.go
+++ b/writer.go
@@ -119,7 +119,7 @@ func (tw *timeoutWriter) WriteHeader(code int) {
 func (tw *timeoutWriter) ReadFrom(src io.Reader) (n int64, err error) {
 	bufPtr := copyBufPool.Get().(*[]byte)
 	buf := *bufPtr
-	// onlyWrite hide "ReadFrom" from w.
+
 	n, err = io.CopyBuffer(onlyWrite{tw}, src, buf)
 	copyBufPool.Put(bufPtr)
 	return

--- a/writer.go
+++ b/writer.go
@@ -10,7 +10,6 @@ package foxtimeout
 import (
 	"bufio"
 	"bytes"
-	"github.com/tigerwill90/fox"
 	"io"
 	"log"
 	"net"
@@ -18,6 +17,8 @@ import (
 	"path"
 	"sync"
 	"time"
+
+	"github.com/tigerwill90/fox"
 )
 
 var _ fox.ResponseWriter = (*timeoutWriter)(nil)


### PR DESCRIPTION
This PR updates the foxtimeout middleware to use Fox router v0.24.0 and introduces a cleaner, more idiomatic approach for per-route timeout configuration.

 ### Key Changes:                                                                                                                             
1. Fox Version Update: Updated from v0.23.0 to v0.24.0
2. Route Annotations for Timeout: Replaced the custom Resolver interface with Fox's native route annotations system
   - Added After(duration) - Set custom timeout for specific routes
   - Added None() - Disable timeout for specific routes (useful for long-running operations)
4. Request Body Control: Added WithAbortRequestBody() option to control whether to set a read deadline on request body after timeout
5. Documentation: Updated examples to use the new API and Fox's updated middleware registration syntax

### Breaking Changes:
- Removed WithTimeoutResolver() option - replaced with route annotations
- Removed Resolver and TimeoutResolverFunc interfaces 
### Migration Guide

#### Before (v0.24.0)
```go
// Custom resolver for dynamic timeout
resolver := TimeoutResolverFunc(func(c fox.Context) (time.Duration, bool) {
    // Custom logic to determine timeout
    if c.Pattern() == "/slow-endpoint" {
        return 30 * time.Second, true
    }
    return 0, false
})

f, _ := fox.New(
    fox.WithMiddlewareFor(
        fox.RouteHandler,
        foxtimeout.Middleware(2*time.Second, foxtimeout.WithTimeoutResolver(resolver)),
    ),
)

f.MustHandle(http.MethodGet, "/fast", FastHandler)
f.MustHandle(http.MethodGet, "/slow-endpoint", SlowHandler)
```

#### After
```go
// Direct, explicit timeout configuration at route level
f, _ := fox.New(
    fox.WithMiddleware(
        foxtimeout.Middleware(2*time.Second),
    ),
)

f.MustHandle(http.MethodGet, "/fast", FastHandler) // uses default 2s timeout
f.MustHandle(http.MethodGet, "/slow-endpoint", SlowHandler, foxtimeout.After(30*time.Second))
f.MustHandle(http.MethodGet, "/download/{file}", DownloadHandler, foxtimeout.None()) // no timeout
```

